### PR TITLE
fix trove search

### DIFF
--- a/app/Http/Controllers/Admin/TroveCrudController.php
+++ b/app/Http/Controllers/Admin/TroveCrudController.php
@@ -61,7 +61,10 @@ class TroveCrudController extends CrudController
             ->wrapper([
                 'href' => function ($crud, $column, $entry) {
                     return url('https://stats4sd.org/resources/' . $entry->id);
-                }]);
+                }])
+            ->searchLogic(function ($query, $column, $searchTerm) {
+                $query->orWhere('title', 'like', "%$searchTerm%");
+            });
 
     }
 


### PR DESCRIPTION
Looks like using a custom connection breaks the default search logic in the crud controller. This PR adds a custom search funciton to fix the issue.

Fixes #19 